### PR TITLE
Add custom sass, add readme section for local dev going forward

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 sudo: required
 node_js: stable
 install:
-  - npm i
+  - npm i && cd themes/doc && npm i && cd ../..
 script:
   - npm run build
 deploy:

--- a/_config.yaml
+++ b/_config.yaml
@@ -36,3 +36,8 @@ marked:
 ignore:
   # development only: ignore sub node_modules when `npm link hexo-theme-doc`
   - '**/node_modules/**/*node_modules'
+
+# node_sass:
+#   includePaths:
+#    - node_modules
+# ```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "hexo deploy",
     "postinstall": "ln -s ../node_modules/hexo-theme-doc ./themes/doc &>/dev/null || true",
-    "start": "hexo s"
+    "start": "hexo clean && hexo s -p 5000"
   },
   "hexo": {
     "version": "3.6.0"

--- a/source/index.md
+++ b/source/index.md
@@ -8,3 +8,13 @@ This is where all developer documentation is hosted.
 + Check out our [blog](https://blog.foam.space)
 + Our [website](https://foam.space).
 + Try the [SpatialIndex](https://beta.foam.space)
+
+## Custom Styles
+
+The original theme's (v0.1.2) documentation state (March 19th 2018) for custom styles is incomplete and inaccurate.
+To develop locally:
+1. `git clone <repo> && cd <repo dir>`
+2. `npm install` (`yarn` may work here)
+3. `cd themes/doc/`
+4. `npm install` (`yarn` does not seem to work here)
+5. `cd` back to root repo dir and `npm run start` or `yarn start`

--- a/source/style/doc.scss
+++ b/source/style/doc.scss
@@ -1,0 +1,3 @@
+$doc-color-primary: red; // set primary color to "red"
+
+@import "../../themes/doc/_doc.scss";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,11 +1228,7 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-ejs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-1.0.0.tgz#c9c60a48a46ee452fb32a71c317b95e5aa1fcb3d"
-
-ejs@^2.5.7:
+ejs@^2.3.4, ejs@^2.5.7:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
@@ -1676,7 +1672,7 @@ hexo-bunyan@^1.0.0:
     mv "~2"
     safe-json-stringify "~1"
 
-hexo-cli@^1.0.3, hexo-cli@^1.1.0:
+hexo-cli@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hexo-cli/-/hexo-cli-1.1.0.tgz#496d238d4646dbfd1cf047b6dc5271bfb5cb798f"
   dependencies:
@@ -1720,11 +1716,11 @@ hexo-log@^0.2.0:
     chalk "^1.1.1"
     hexo-bunyan "^1.0.0"
 
-hexo-renderer-ejs@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/hexo-renderer-ejs/-/hexo-renderer-ejs-0.2.0.tgz#80771935a5cc71513f07c2c7c14f006220817ae0"
+hexo-renderer-ejs@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/hexo-renderer-ejs/-/hexo-renderer-ejs-0.3.1.tgz#c0c1a3757532d47e5b7d9dc908b5dfd98c94be2c"
   dependencies:
-    ejs "^1.0.0"
+    ejs "^2.3.4"
     object-assign "^4.0.1"
 
 hexo-renderer-less@^0.2.0:
@@ -1733,14 +1729,14 @@ hexo-renderer-less@^0.2.0:
   dependencies:
     less "^2.5.1"
 
-hexo-renderer-marked@^0.2.10:
-  version "0.2.11"
-  resolved "https://registry.yarnpkg.com/hexo-renderer-marked/-/hexo-renderer-marked-0.2.11.tgz#32fd3880d3c3979fd7b8015ec121a6c44ff49f84"
+hexo-renderer-marked@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/hexo-renderer-marked/-/hexo-renderer-marked-0.3.2.tgz#d6a37af9ff195e30f9ef6ede1a06ea1fe4322966"
   dependencies:
-    hexo-util "^0.6.0"
-    marked "^0.3.5"
-    object-assign "^4.1.0"
-    strip-indent "^1.0.1"
+    hexo-util "^0.6.2"
+    marked "^0.3.9"
+    object-assign "^4.1.1"
+    strip-indent "^2.0.0"
 
 hexo-renderer-sass@^0.3.2:
   version "0.3.2"
@@ -1748,9 +1744,9 @@ hexo-renderer-sass@^0.3.2:
   dependencies:
     node-sass "^4.5.3"
 
-hexo-server@^0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/hexo-server/-/hexo-server-0.2.2.tgz#592686b554b8bfe09a19bc86c0f003ac3e8c19b9"
+hexo-server@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/hexo-server/-/hexo-server-0.3.1.tgz#86956fe7ff6bb9407f99a113666c3f1278a47979"
   dependencies:
     bluebird "^3.0.6"
     chalk "^1.1.1"
@@ -1762,7 +1758,7 @@ hexo-server@^0.2.1:
     opn "^4.0.0"
     serve-static "^1.10.0"
 
-hexo-theme-doc@^0.1.0:
+hexo-theme-doc@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/hexo-theme-doc/-/hexo-theme-doc-0.1.2.tgz#fc267052ca4d7c138b83fa6337969731f448897f"
   dependencies:
@@ -1795,7 +1791,7 @@ hexo-theme-doc@^0.1.0:
     url-join "^2.0.2"
     valid-url "^1.0.9"
 
-hexo-util@^0.6.0:
+hexo-util@^0.6.0, hexo-util@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/hexo-util/-/hexo-util-0.6.3.tgz#16a2ade457bef955af0dfd22a3fe6f0a49a9137c"
   dependencies:
@@ -1806,7 +1802,7 @@ hexo-util@^0.6.0:
     html-entities "^1.2.0"
     striptags "^2.1.1"
 
-hexo@^3.3.8:
+hexo@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/hexo/-/hexo-3.6.0.tgz#f978263eb889655269902bc60cd0dfaa29d63c0f"
   dependencies:
@@ -2387,7 +2383,7 @@ markdown@~0.5.0:
   dependencies:
     nopt "~2.1.1"
 
-marked@^0.3.5:
+marked@^0.3.9:
   version "0.3.17"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.17.tgz#607f06668b3c6b1246b28f13da76116ac1aa2d2b"
 


### PR DESCRIPTION
This theme uses relative paths that point to it's own node_modules, which are not always installed in favor of modules/dependancies in the upper project node_modules dir. This breaks the rel path. I'm not sure if there is a better way to resolve this issue other than the steps in the readme of this PR.

The last important piece of info is that this theme's maintainers have an open PR for this issue that might be resolved soon. https://github.com/zalando-incubator/hexo-theme-doc/issues/123

- [x] make travis work again

Some other research into this issue: 
- This command may work: `npm install --legacy-bundling`